### PR TITLE
web: Fix authorizing API `fetchi`ing not to fail

### DIFF
--- a/web/common/api.ts
+++ b/web/common/api.ts
@@ -48,7 +48,16 @@ const call = (
     credentials: "include",
   });
 
-  return resp;
+  return resp.then(
+    (response) =>
+      new Promise((resolve, reject) => {
+        if (response.ok) {
+          resolve(response);
+        } else {
+          reject(response);
+        }
+      })
+  );
 };
 
 export const post = (

--- a/web/common/auth.tsx
+++ b/web/common/auth.tsx
@@ -31,8 +31,10 @@ export const useMe = (ctx?: NextPageContext): UserData | null => {
 export const getSession = (ctx?: NextPageContext): string | null => {
   const cookies = nookies.get(ctx);
   const { session } = cookies;
+  console.log({ cookies, session: cookies.session });
 
   if (typeof session === "undefined") {
+    console.log("undefined error", { cookies, session: cookies.session });
     throw TypeError("no session");
   }
 

--- a/web/common/auth.tsx
+++ b/web/common/auth.tsx
@@ -31,12 +31,6 @@ export const useMe = (ctx?: NextPageContext): UserData | null => {
 export const getSession = (ctx?: NextPageContext): string | null => {
   const cookies = nookies.get(ctx);
   const { session } = cookies;
-  console.log({ cookies, session: cookies.session });
-
-  if (typeof session === "undefined") {
-    console.log("undefined error", { cookies, session: cookies.session });
-    throw TypeError("no session");
-  }
 
   return session;
 };

--- a/web/pages/home.tsx
+++ b/web/pages/home.tsx
@@ -40,16 +40,17 @@ const Home: NextPage<HomeProps> = ({ threads }) => {
 
   useEffect(() => {
     const fetchFeed = async () => {
-      const resp = await get(`/responses/feed`).catch(function (err) {
-        if (err.status === 401) {
+      try {
+        const resp = await get(`/responses/feed`);
+        const json = await resp.json();
+        const { responses } = json;
+        setResponses(responses);
+      } catch (err) {
+        if (err?.status === 401) {
           console.error("unauthorized");
-          return router.push("/") as never;
+          router.push("/");
         }
-      });
-
-      const json = await resp.json();
-      const { responses } = json;
-      setResponses(responses);
+      }
     };
 
     fetchFeed();


### PR DESCRIPTION
`/home` was throwing on error if not authorized (#31 ).

I solved this by limiting such API calls to happen only on the client-side.